### PR TITLE
Add gulp to package script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulp-util": "^3.0.8"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "gulp": "gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Because gulp-cli cannot be installed globally on the SMU server, gulp
needs to be run via package.json. This way, gulp can be run with the
command "npm run gulp". Added gulp script to package.json file.