### PR TITLE
Create blank SECRET.key file

### DIFF
--- a/run/SECRET.key
+++ b/run/SECRET.key
@@ -1,0 +1,1 @@
+!93&_e1qnm1oz4hjs+-y3i%3-+&5i)g7i)_-on(qa-yw0w4-in


### PR DESCRIPTION
Builds were failing because this file was missing. Created file.