### PR TITLE
Add requirement to production build

### DIFF
--- a/northwood/settings/production.py
+++ b/northwood/settings/production.py
@@ -1,6 +1,8 @@
 # for now fetch the development settings only
 #from .development import *
 
+import dj_database_url
+
 # turn off all debugging
 DEBUG = False
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,4 @@
+dj-database-url==0.5.0
 Django==2.1.3
 mysqlclient==1.3.13
 pytz==2018.7


### PR DESCRIPTION
Added dj-database-url utility to use DATABASE_URL environment variable
to point Django at the database.