### PR TITLE
Remove line with database URL

### DIFF
--- a/northwood/settings/production.py
+++ b/northwood/settings/production.py
@@ -35,4 +35,3 @@ SERVER_EMAIL = 'root@localhost'
 PASSWORD_RESET_TIMEOUT_DAYS = 1
 
 DATABASES = {}
-DATABASES['default'] = dj_database_url.config(default=DATABASE_URL)


### PR DESCRIPTION
Ansible cannot find the environment variable DATABASE_URL when it goes
to run the manage.py script. Perhaps, this is due to switching to a
virtual environment. As a workaround, automation builds will append a
line containing the URL to the settings file.