### PR TITLE
Add check for empty SECRET_KEY

### DIFF
--- a/northwood/settings/common.py
+++ b/northwood/settings/common.py
@@ -126,12 +126,12 @@ DEBUG = False
 # finally grab the SECRET KEY
 try:
     SECRET_KEY = open(SECRET_FILE).read().strip()
-except IOError:
-    try:
-        from django.utils.crypto import get_random_string
-        chars = 'abcdefghijklmnopqrstuvwxyz0123456789!$%&()=+-_'
-        SECRET_KEY = get_random_string(50, chars)
-        with open(SECRET_FILE, 'w') as f:
-            f.write(SECRET_KEY)
-    except IOError:
-        raise Exception('Could not open %s for writing!' % SECRET_FILE)
+    if not SECRET_KEY:
+        try:
+            from django.utils.crypto import get_random_string
+            chars = 'abcdefghijklmnopqrstuvwxyz0123456789!$%&()=+-_'
+            SECRET_KEY = get_random_string(50, chars)
+            with open(SECRET_FILE, 'w') as f:
+                f.write(SECRET_KEY)
+        except IOError:
+            raise Exception('Could not open %s for writing!' % SECRET_FILE)


### PR DESCRIPTION
Production builds were failing because SECRET.key is empty. The template
includes a try block for creating a new key on error but does not create
it if the file is simply empty. Added if statement.